### PR TITLE
fix: remove fprintf for WASM compatibility

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,5 +1,5 @@
 #include <ctype.h>
-#include <stdio.h>
+#include <stdlib.h>
 #include <wctype.h>
 
 #include "tree_sitter/parser.h"
@@ -40,10 +40,6 @@ void tree_sitter_doxygen_external_scanner_deserialize(void *payload, const char 
         scanner->codeblock_delimiter_length = (uint32_t)buffer[0];
         scanner->codeblock_start_column = (uint32_t)buffer[1];
     } else if (length != 0 && length != 2) {
-        fprintf(stderr,
-                "tree-sitter-doxygen: Invalid buffer length %d! This should "
-                "never happen\n",
-                length);
         abort();
     }
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include "tree_sitter/alloc.h"
 #include "tree_sitter/parser.h"
 
 // Inline replacements for libc functions unavailable in Zed's WASM sandbox


### PR DESCRIPTION
## Summary
Make the external scanner WASM-compatible so it can be used in editors like Zed that compile tree-sitter grammars to WASM.

## Changes
- Replace `fprintf(stderr, ...)` with just `abort()` (fprintf unavailable in WASM)
- Replace `isalnum`, `isalpha`, `iswspace` from `<ctype.h>`/`<wctype.h>` with inline implementations (unavailable in WASM sandbox)
- Replace `calloc`/`free` with `ts_calloc`/`ts_free` from `tree_sitter/alloc.h` (proper tree-sitter allocator API)
- Remove `<stdio.h>`, `<ctype.h>`, `<wctype.h>`, `<stdlib.h>` includes

## Context
Zed compiles tree-sitter grammars to WASM and its sandbox provides only a minimal libc subset. The original scanner uses several libc functions that aren't available, causing:
```
Failed to instantiate Wasm module: invalid import 'fprintf'
Failed to instantiate Wasm module: invalid import 'isalnum'
```

This prevents C, C++, and Java extensions from using doxygen injection for Javadoc/Doxygen highlighting.